### PR TITLE
Removes unused reference to WINDOW*

### DIFF
--- a/x509ls/cli/base/text_control.cc
+++ b/x509ls/cli/base/text_control.cc
@@ -33,9 +33,6 @@ bool TextControl::Scroll(const enum ScrollDirection direction, int lines) {
     return false;
   }
 
-  WINDOW* window = Window();
-  assert(window != NULL);
-
   int adjustment = lines != 0 ? lines : Rows();
   if (direction == kDirectionUp) {
     adjustment = -adjustment;


### PR DESCRIPTION
This causes Release mode builds to fail because `-DNDEBUG` gets set which turns off `assert` statements.
